### PR TITLE
chore(package.json): update supported engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "karma": "./bin/karma"
   },
   "engines": {
-    "node": "~0.8 || ~0.10"
+    "node":  ">=0.8 <=0.12",
+    "iojs": "~1"
   },
   "version": "0.0.4"
 }


### PR DESCRIPTION
Now karma support node@0.12 and iojs@1.x.x
@see https://github.com/karma-runner/karma/pull/1353