### PR TITLE
chore(release): v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# [2.0.0](https://github.com/karma-runner/karma-cli/compare/v1.0.1...v2.0.0) (2018-11-26)
+
+
+### chore
+
+* update required node version to 6 ([951d247](https://github.com/karma-runner/karma-cli/commit/951d247))
+
+
+### BREAKING CHANGES
+
+* Node versions previous to 6 are no longer supported.
+
+
+
 <a name"1.0.1"></a>
 ### 1.0.1 (2016-06-26)
 

--- a/package.json
+++ b/package.json
@@ -29,13 +29,16 @@
   "contributors": [
     "Vojta Jina <vojta.jina@gmail.com>",
     "Friedel Ziegelmayer <dignifiedquire@gmail.com>",
+    "rogeriopvl <rogeriopvl@gmail.com>",
     "Jan Raasch <jan@janraasch.com>",
-    "Mark Ethan Trostler <mark@zzo.com>",
+    "Rogério Vicente <rogeriopvl@gmail.com>",
     "Maksim Ryzhikov <rv.maksim@gmail.com>",
-    "Robo <hop2deep@gmail.com>",
+    "Mark Ethan Trostler <mark@zzo.com>",
+    "Piper Chester <piperchester@gmail.com>",
+    "Brian Hann <emailc0bra@gmail.com>",
     "Bas Bosman <github@nazgul.nu>",
-    "deepak1556 <hop2deep@gmail.com>",
-    "Brian Hann <emailc0bra@gmail.com>"
+    "Robo <hop2deep@gmail.com>",
+    "deepak1556 <hop2deep@gmail.com>"
   ],
   "dependencies": {
     "resolve": "^1.3.3"

--- a/package.json
+++ b/package.json
@@ -58,6 +58,6 @@
   "engines": {
     "node": ">= 6"
   },
-  "version": "1.0.1",
+  "version": "2.0.0",
   "license": "MIT"
 }


### PR DESCRIPTION
Here's a much needed release :)

Latest release was on Jun 26, 2016. I don't have NPM permissions to publish, so that's the only step needed after merging this PR.

Edit: and also push the tag

cc @dignifiedquire @johnjbarton 